### PR TITLE
New and easier to use locks configuration screen.

### DIFF
--- a/shared_locked_chest.lua
+++ b/shared_locked_chest.lua
@@ -1,3 +1,5 @@
+
+-- 25.02.16 Added new Locks config Buttons.
 -- 09.01.13 Added support for pipeworks.
 
 
@@ -47,17 +49,14 @@ minetest.register_node("locks:shared_locked_chest", {
                 local meta = minetest.env:get_meta(pos)
                 -- prepare the lock of the chest
                 locks:lock_init( pos, 
-                                "size[8,10]"..
---                                "field[0.5,0.2;8,1.0;locks_sent_lock_command;Locked chest. Type password, command or /help for help:;]"..
---                                "button_exit[3,0.8;2,1.0;locks_sent_input;Proceed]"..
-                                "list[current_name;main;0,0;8,4;]"..
-                                "list[current_player;main;0,5;8,4;]"..
-                                "field[0.3,9.6;6,0.7;locks_sent_lock_command;Locked chest. Type /help for help:;]"..
-								"background[-0.5,-0.65;9,11.2;bg_shared_locked_chest.jpg]"..
-                                "button_exit[6.3,9.2;1.7,0.7;locks_sent_input;Proceed]" );
---                                "size[8,9]"..
---                                "list[current_name;main;0,0;8,4;]"..
---                                "list[current_player;main;0,5;8,4;]");
+					"size[8,10]" ..
+					locks.uniform_background ..
+					"list[current_name;main;0,1.3;8,4;]" ..
+					"list[current_player;main;0,5.85;8,1;]" ..
+					"list[current_player;main;0,7.08;8,3;8]" ..
+					"listring[current_name;main]" ..
+					"listring[current_player;main]" ..
+					default.get_hotbar_bg(0,5.85) );
                 local inv = meta:get_inventory()
                 inv:set_size("main", 8*4)
         end,

--- a/shared_locked_furnace.lua
+++ b/shared_locked_furnace.lua
@@ -3,6 +3,7 @@
 -- containing only the furnace and adopted slightly for my locks mod
 
 
+-- 25.02.16 Added new Locks config Buttons.
 -- 09.01.13 Added support for pipeworks.
 
 
@@ -92,10 +93,10 @@ function locks.get_furnace_active_formspec(pos, percent)
 		"list[current_name;src;2,1;1,1;]"..
 		"list[current_name;dst;5,1;2,2;]"..
 		"list[current_player;main;0,5;8,4;]"..
-		"background[-0.5,-0.65;9,10.35;bg_shared_locked_furnace.jpg]"..
-
-                                "field[0.3,4.5;6,0.7;locks_sent_lock_command;Locked furnace. Type /help for help:;]"..
-                                "button_exit[6.3,4;1.7,0.7;locks_sent_input;Proceed]" ;
+		locks.uniform_background..
+		locks.get_authorize_button(6,0)..
+		locks.get_config_button(7,0)
+		
 	return formspec
 end
 
@@ -106,9 +107,9 @@ locks.furnace_inactive_formspec =
 	"list[current_name;src;2,1;1,1;]"..
 	"list[current_name;dst;5,1;2,2;]"..
 	"list[current_player;main;0,5;8,4;]"..
-	"background[-0.5,-0.65;9,10.35;bg_shared_locked_furnace.jpg]"..
-                                "field[0.3,4.5;6,0.7;locks_sent_lock_command;Locked furnace. Type /help for help:;]"..
-                                "button_exit[6.3,4;1.7,0.7;locks_sent_input;Proceed]" ;
+	locks.uniform_background..
+	locks.get_authorize_button(6,0)..
+	locks.get_config_button(7,0)
 
 minetest.register_node("locks:shared_locked_furnace", {
 	description = "Shared locked furnace",

--- a/shared_locked_sign_wall.lua
+++ b/shared_locked_sign_wall.lua
@@ -1,4 +1,5 @@
 
+-- 25.02.16 Added new Locks config Buttons.
 -- allow aborting with ESC in newer Versions of MT again
 
 -- a sign
@@ -28,9 +29,8 @@ minetest.register_node("locks:shared_locked_sign_wall", {
                 locks:lock_init( pos, 
                                 "size[8,4]"..
                                 "field[0.3,0.6;6,0.7;text;Text:;${text}]"..
-                                "field[0.3,3.6;6,0.7;locks_sent_lock_command;Locked sign. Type /help for help:;]"..
                                 "button_exit[6.3,3.2;1.7,0.7;locks_sent_input;Proceed]"..
-								"background[-0.5,-0.5;9,5;bg_shared_locked_sign.jpg]" );
+								locks.uniform_background );
         end,
 
         after_place_node = function(pos, placer)
@@ -44,10 +44,12 @@ minetest.register_node("locks:shared_locked_sign_wall", {
 
         on_receive_fields = function(pos, formname, fields, sender)
 	
-                -- if the user already has the right to use this and did input text
-                if(     fields.text 
-                    and ( not(fields.locks_sent_lock_command) 
-                           or fields.locks_sent_lock_command=="")
+                -- if locks can not  handle the input 
+				if not locks:lock_handle_input( pos, formname, fields, sender ) then
+					--then handle compatibility stuff or insert text
+					if(     fields.text 
+                    and ( not(fields.locks_sent_lock_command) --compatibility
+                           or fields.locks_sent_lock_command=="") --compatibility
                     and locks:lock_allow_use( pos, sender )) then
 
                     --print("Sign at "..minetest.pos_to_string(pos).." got "..dump(fields))
@@ -57,11 +59,8 @@ minetest.register_node("locks:shared_locked_sign_wall", {
                                 "\" to sign at "..minetest.pos_to_string(pos));
                     meta:set_string("text", fields.text);
                     meta:set_string("infotext", '"'..fields.text..'"'.." ["..sender:get_player_name().."]");
-
-                -- a command for the lock?
-                else
-                   locks:lock_handle_input( pos, formname, fields, sender );
-                end
+				end
+			end
   
         end,
  });

--- a/shared_locked_xdoors2.lua
+++ b/shared_locked_xdoors2.lua
@@ -2,6 +2,7 @@
 -- modified by Sokomine to allow locked doors that can only be opened/closed/dig up by the player who placed them
 -- a little bit modified by addi to allow someone with the priv "opendoors" to open/close/dig all locked doors. 
 -- Sokomine: modified again so that it uses the new locks-mod
+-- 25.02.16 Added new Locks config Buttons.
 
 local door_bottom = {-0.5, -0.5, -0.5, 0.5, 0.5, -0.4}
 local door_top = {
@@ -77,8 +78,8 @@ for i = 1, 2 do
         on_construct = function(pos)
                 locks:lock_init( pos,
                                "size[8,2]"..
-                               "field[0.3,0.6;6,0.7;locks_sent_lock_command;Locked door. Type /help for help:;]"..
-                               "button_exit[6.3,1.2;1.7,0.7;locks_sent_input;Proceed]" );
+							   locks.uniform_background..
+                               "button_exit[6.3,1.2;1.7,1;locks_sent_input;Proceed]" );
         end,
 
         on_receive_fields = function(pos, formname, fields, sender)
@@ -110,8 +111,8 @@ for i = 1, 2 do
         on_construct = function(pos)
                 locks:lock_init( pos,
                                "size[8,2]"..
-                               "field[0.3,0.6;6,0.7;locks_sent_lock_command;Locked door. Type /help for help:;]"..
-                               "button_exit[6.3,0.2;1.7,0.7;locks_sent_input;Proceed]" );
+							   locks.uniform_background..
+                               "button_exit[6.3,1.2;1.7,1;locks_sent_input;Proceed]" );
         end,
 
         on_receive_fields = function(pos, formname, fields, sender)


### PR DESCRIPTION
Hi, I added a more modern Configuration formspec.
It provides a better overview and usability. 

Everything in this Formspec is sent to player via minetest.show_formspec, so no additional laggy set_meta is required. 

The configuration Formspec can accessed by pressing the button "Locks config"
the password prompt can accesst by pressing the button "Authorize"

And the best is: Its still compatible to the old nodes. The old interface is still aviable and working for compatibility reasons.

*_Screenshots: *_

![chest_inventory](https://cloud.githubusercontent.com/assets/3142688/13315142/5855b3e6-dba9-11e5-8744-3117682b8838.png)
![configuration_formspec](https://cloud.githubusercontent.com/assets/3142688/13315144/5cd591de-dba9-11e5-9780-e36555c43ac8.png)
![password_prompt](https://cloud.githubusercontent.com/assets/3142688/13315145/62c5ad0e-dba9-11e5-9550-477cbd6fa4f9.png)
![acces_denied_because_of_wrong_password](https://cloud.githubusercontent.com/assets/3142688/13315147/68d1665c-dba9-11e5-8d72-ed7a42b62522.png)
