### PR TITLE
Fix crash when a client sends empty fields

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -455,12 +455,7 @@ function locks:lock_handle_input( pos, formname, fields, player )
 
 
    -- is this input the lock is supposed to handle?
-   if(  ( not( fields.locks_sent_lock_command )
-       or fields.locks_sent_lock_command == "" )
-      and (fields.quit and (fields.quit==true or fields.quit=='true'))) then
---    or not( fields.locks_sent_input )
-     return;
-   end
+   if fields.quit or not fields.locks_sent_lock_command then return end
 
    if( fields.locks_sent_lock_command == "/help" ) then
 


### PR DESCRIPTION
Fixes #18

This prevents the server from crashing if a locked node receives fields where "locks_sent_lock_command" is nil. This seems to happen occasionally with some clients for reasons I have not yet identified. I suspect it has something to do with the user doing something "invalid" for the current page and may even involve a race condition, but... regardless, this just changes it so that if nothing was sent for it to do then it just doesn't do anything.

As a side note, the "locks_sent_lock_command" field doesn't seem to ever actually be used, but I left the code for handing it in place as I'm assuming there's some reason behind it.